### PR TITLE
Bump version and bump evervault-sdk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@evervault/react",
-  "version": "0.1.11",
+  "version": "0.1.13",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -963,9 +963,9 @@
       }
     },
     "@evervault/sdk": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/@evervault/sdk/-/sdk-0.3.9.tgz",
-      "integrity": "sha512-CGx6dAV8dnCa4NVUI2Pqa6Q1TGsbMqCJujLaaaXR9psxeSBOfHqSn1ibtBvOCc6CEwuNMbMNeXd2Neb9Fa9J4A=="
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@evervault/sdk/-/sdk-0.4.0.tgz",
+      "integrity": "sha512-OVDYchzq4uX2MsMoD98dvL3q4lWyv7sApkLKnSyWbun3izK2mc67NZlOF9dRZvmPfLcQc6ZC+YXvQAyoJgq6DQ=="
     },
     "@webassemblyjs/ast": {
       "version": "1.8.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@evervault/react",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "description": "React package for the Evervault SDK",
   "main": "./build/lib/index.js",
   "scripts": {
@@ -13,7 +13,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@evervault/sdk": "0.3.9",
+    "@evervault/sdk": "0.4.0",
     "prop-types": "^15.7.2"
   },
   "devDependencies": {


### PR DESCRIPTION
# Why
We need to bump the version on develop so the new refresh token endpoint works
