### PR TITLE
Changing version from 0.2.4 to 0.2.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@evervault/react",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "React package for the Evervault SDK",
   "main": "./build/lib/index.js",
   "scripts": {


### PR DESCRIPTION
# Why
Currently cannot merge [this](https://github.com/evervault/ui/pull/967) PR as the React SDK changes from [here](https://github.com/evervault/evervault-react/pull/35) are not deployed to npm.

# How
By changing the version number, this will auto-deploy to npm. Once this is complete, we can merge out the UI work as it will pull in the new changes from the React SDK.