### PR TITLE
Update react peer dependency to be >=16.12.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@evervault/react",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "React package for the Evervault SDK",
   "main": "./build/lib/index.js",
   "scripts": {
@@ -8,7 +8,7 @@
     "build": "npx webpack --mode=production"
   },
   "peerDependencies": {
-    "react": "^16.12.0"
+    "react": ">=16.12.0"
   },
   "author": "",
   "license": "ISC",


### PR DESCRIPTION
# Why
Fixes warning when installing `@evervault/react` on projects with React 17.
```bash
warning " > @evervault/react@0.2.5" has incorrect peer dependency "react@^16.12.0".
```

# How
Uses `>=` instead of `^` to match newer versions of React as well.