### PR TITLE
docs: adding documentation on using custom labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,13 +85,33 @@ Simply pass the id of the element in which the iFrame should be embedded.
 We also support [themes](https://docs.evervault.com/concepts/inputs/overview#customising-inputs) so you can customise how Inputs looks in your UI.
 
 ```javascript
-evervault.inputs(id: String, theme: String);
+evervault.inputs(id: String, config: Object);
 ```
 
 | Parameter | Type   | Description                                                               |
 | --------- | ------ | ------------------------------------------------------------------------- |
 | id        | string | Id of the element in which the Evervault Inputs iFrame should be embedded |
-| theme     | string | Optional theme for styling Inputs, currently supported: minimal           |
+| config    | Object | A config object for custom styling.                                       |
+
+#### config
+
+| Parameter                  | Type   | Description                                                                        |
+| -------------------------- | ------ | ---------------------------------------------------------------------------------- |
+| theme                      | String | The base styling for Inputs. Currently supports default, minimal and material.     |
+| height                     | String | The height of the Evervault Inputs iframe.                                         |
+| primaryColor               | String | The main theme color.                                                              |
+| labelColor                 | String | The color CSS property applied to the input labels.                                |
+| inputBorderColor           | String | The border-color CSS property applied to inputs.                                   |
+| inputTextColor             | String | The color CSS property applied to inputs.                                          |
+| inputBackgroundColor       | String | The color CSS property applied to the ::placeholder CSS pseudo-element for inputs. |
+| inputBorderRadius          | String | The border-radius CSS property applied to inputs.                                  |
+| inputHeight                | String | The height CSS property applied to inputs.                                         |
+| cardNumberLabel            | String | The label for the card number input                                                |
+| expirationDateLabel        | String | The label for the expiration date input                                            |
+| securityCodeLabel          | String | The label for the security code input                                              |
+| invalidCardNumberLabel     | String | The message shown on an invalid card number                                        |
+| invalidExpirationDateLabel | String | The message shown on an invalid expiration date                                    |
+| invalidSecurityCodeLabel   | String | The message shown on an invalid security code                                      |
 
 #### Retrieving card data
 
@@ -144,6 +164,23 @@ This option is best when you are looking to retrieve card data occasionally, lik
 ```javascript
 const cardData = await inputs.getData();
 ```
+
+#### Localization
+
+The iFrame can be localized on initialization by providing a set of labels in the [config](#config). The labels can then be updated as required using the `setLabels` method.
+
+```javascript
+await inputs.setLabels({});
+```
+
+| Parameter                  | Type   | Description                                     |
+| -------------------------- | ------ | ----------------------------------------------- |
+| cardNumberLabel            | String | The label for the card number input             |
+| expirationDateLabel        | String | The label for the expiration date input         |
+| securityCodeLabel          | String | The label for the security code input           |
+| invalidCardNumberLabel     | String | The message shown on an invalid card number     |
+| invalidExpirationDateLabel | String | The message shown on an invalid expiration date |
+| invalidSecurityCodeLabel   | String | The message shown on an invalid security code   |
 
 ## Contributing
 


### PR DESCRIPTION
# Why
The user should be able to set the labels they wish to use in their iframe, in particular as it will allow localization

# How
Updated readme